### PR TITLE
Upgrade grib2io to support new grib messages

### DIFF
--- a/ecf/ensstat/jaigefs_ens_debias.ecf
+++ b/ecf/ensstat/jaigefs_ens_debias.ecf
@@ -14,8 +14,19 @@ export model=aigefs
 export cyc=%CYC%
 export fh=%FHR%
 
+module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
+module load craype/${craype_ver:?}
+module load cray-mpich/${cray_mpich_ver:?}
+module load netcdf-D/${netcdf_D_ver:?}
+module load libaec/${libaec_ver:?}
+module load ip/${ip_ver:?}
+module load g2c/${g2c_ver:?}
+module load jasper/${jasper_ver:?}
+module load libpng/${libpng_ver:?}
+module load zlib/${zlib_ver:?}
 module load wgrib2/${wgrib2_ver:?}
+module load libjpeg-turbo/${libjpeg_turbo_ver:?}
 module load libjpeg/${libjpeg_ver:?}
 
 module list

--- a/ecf/ensstat/jaigefs_ens_debias.ecf
+++ b/ecf/ensstat/jaigefs_ens_debias.ecf
@@ -14,7 +14,6 @@ export model=aigefs
 export cyc=%CYC%
 export fh=%FHR%
 
-module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
 module load craype/${craype_ver:?}
 module load cray-mpich/${cray_mpich_ver:?}

--- a/ecf/jaigefs_forecast.ecf
+++ b/ecf/jaigefs_forecast.ecf
@@ -14,7 +14,6 @@ export model=aigefs
 
 export cyc=%CYC%
 
-module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
 module load craype/${craype_ver:?}
 module load cray-mpich/${cray_mpich_ver:?}

--- a/ecf/jaigefs_forecast.ecf
+++ b/ecf/jaigefs_forecast.ecf
@@ -14,7 +14,17 @@ export model=aigefs
 
 export cyc=%CYC%
 
+module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
+module load craype/${craype_ver:?}
+module load cray-mpich/${cray_mpich_ver:?}
+module load netcdf-D/${netcdf_D_ver:?}
+module load libaec/${libaec_ver:?}
+module load ip/${ip_ver:?}
+module load g2c/${g2c_ver:?}
+module load jasper/${jasper_ver:?}
+module load libpng/${libpng_ver:?}
+module load zlib/${zlib_ver:?}
 module load wgrib2/${wgrib2_ver:?}
 module load libjpeg-turbo/${libjpeg_turbo_ver:?}
 

--- a/ecf/jaigefs_prep.ecf
+++ b/ecf/jaigefs_prep.ecf
@@ -14,7 +14,6 @@ export model=aigefs
 
 export cyc=%CYC%
 
-module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
 module load craype/${craype_ver:?}
 module load cray-mpich/${cray_mpich_ver:?}

--- a/ecf/jaigefs_prep.ecf
+++ b/ecf/jaigefs_prep.ecf
@@ -14,7 +14,17 @@ export model=aigefs
 
 export cyc=%CYC%
 
+module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
+module load craype/${craype_ver:?}
+module load cray-mpich/${cray_mpich_ver:?}
+module load netcdf-D/${netcdf_D_ver:?}
+module load libaec/${libaec_ver:?}
+module load ip/${ip_ver:?}
+module load g2c/${g2c_ver:?}
+module load jasper/${jasper_ver:?}
+module load libpng/${libpng_ver:?}
+module load zlib/${zlib_ver:?}
 module load wgrib2/${wgrib2_ver:?}
 module load libjpeg-turbo/${libjpeg_turbo_ver:?}
 

--- a/ecf/post/jaigefs_post.ecf
+++ b/ecf/post/jaigefs_post.ecf
@@ -16,9 +16,19 @@ export cyc=%CYC%
 export MEMBER=%MEMBER% # mem000-mem030
 export fh=%FHR%
 
+module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
+module load craype/${craype_ver:?}
+module load cray-mpich/${cray_mpich_ver:?}
+module load netcdf-D/${netcdf_D_ver:?}
+module load libaec/${libaec_ver:?}
+module load ip/${ip_ver:?}
+module load g2c/${g2c_ver:?}
+module load jasper/${jasper_ver:?}
+module load libpng/${libpng_ver:?}
+module load zlib/${zlib_ver:?}
 module load wgrib2/${wgrib2_ver:?}
-#module load libjpeg-turbo/${libjpeg_turbo_ver:?}
+module load libjpeg-turbo/${libjpeg_turbo_ver:?}
 
 module list
 

--- a/ecf/post/jaigefs_post.ecf
+++ b/ecf/post/jaigefs_post.ecf
@@ -16,7 +16,6 @@ export cyc=%CYC%
 export MEMBER=%MEMBER% # mem000-mem030
 export fh=%FHR%
 
-module load PrgEnv-intel/${PrgEnv_intel_ver:?}
 module load intel/${intel_ver:?}
 module load craype/${craype_ver:?}
 module load cray-mpich/${cray_mpich_ver:?}

--- a/sorc/requirements.txt.j2
+++ b/sorc/requirements.txt.j2
@@ -29,7 +29,7 @@ flexparser==0.4
 fonttools==4.58.1
 fsspec==2025.5.1
 graphcast@git+https://github.com/NOAA-EMC/graphcast.git@3fde6d4
-grib2io==2.5.4
+grib2io==2.6.0
 humanize==4.12.3
 idna==3.10
 importlib_metadata==8.7.0

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,4 @@
 #
-export PrgEnv_intel_ver=8.3.3
 export intel_ver=19.1.3.304
 export craype_ver=2.7.17
 export cray_mpich_ver=8.1.19

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,18 +1,18 @@
 #
+export PrgEnv_intel_ver=8.3.3
 export intel_ver=19.1.3.304
-export wgrib2_ver=2.0.8
+export craype_ver=2.7.17
+export cray_mpich_ver=8.1.19
+export netcdf_D_ver=4.9.2
+export libaec_ver=1.1.3
+export ip_ver=5.2.0
+export g2c_ver=2.3.0
+export jasper_ver=2.0.25
+export libpng_ver=1.6.37
+export zlib_ver=1.2.11
+export wgrib2_ver=3.8.0
 export python_ver=3.12
 export libjpeg_turbo_ver=2.1.0
 export libjpeg_ver=9c # for JAIGEFS_ENS_DEBIAS
 
 export gefs_ver="v12.3"
-
-# PARA/TEST
-#export COMPATH=/lfs/h1/ops/prod/com/gefs
-#export MAILTO="russell.manser@noaa.gov, carlos.m.diaz@noaa.gov"
-
-#export SENDDBN=NO
-#export DBNLOG=YES
-#export DATAROOT=/lfs/f1/ops/para/tmp
-
-#export PDY=20250923


### PR DESCRIPTION
This PR upgrades `grib2io==2.5.4` to `grib2io==2.6.0` to support NOAA-EMC/MLGlobal#67.

The venv build log can be found on Cactus at

`/lfs/h1/nco/idsb/noscrub/russell.manser/tmp/build_venv.20251110_1610.log`