### PR TITLE
Fix code bug that causes missing f006 APCP

### DIFF
--- a/jobs/JAIGEFS_ENS_DEBIAS
+++ b/jobs/JAIGEFS_ENS_DEBIAS
@@ -114,6 +114,15 @@ export err=$?; err_chk
 #cat $DATAHOLD/dir_avgspr_bc/$pgmout.360_avgspr
 #cat $DATAHOLD/dir_avgspr/$pgmout.360_avgspr
 
+# Print exec output
+if [ -e ${pgmout}.${fh}_avgspr_pres ]; then
+  cat ${pgmout}.${fh}_avgspr_pres
+fi
+if [ -e ${pgmout}.${fh}_avgspr_sfc ]; then
+  cat ${pgmout}.${fh}_avgspr_sfc
+fi
+
+
 msg="JOB COMPLETED NORMALLY"
 postmsg "$jlogfile" "$msg"
 

--- a/sorc/aigefs_ensstat.fd/ensstat.f90
+++ b/sorc/aigefs_ensstat.fd/ensstat.f90
@@ -254,12 +254,6 @@ if(nfiles.gt.2) then
       print *, '   '; print *,' variable has member',inum; print *, '   '
       if(inum.gt.navg_min) then
 
-        ! Skip variables total accumulated APCP               
-
-        if(ipd1.eq.1.and.ipd2.eq.8.and.ipd9.eq.0.and.ipd30.gt.0) then
-           print *, '   '; print *,' Skip variables total accumulated APCP '; print *, '   '
-        else
-
         print *, '   '; print *,  ' Combined Ensemble Data Example at Point 8601 '
         write (*,'(10f8.1)') (fgrid(8601,i),i=1,inum)
         print *, '   '
@@ -376,7 +370,6 @@ if(nfiles.gt.2) then
         call putgb2(icfopg2,gfldo,jret)
         call printinfr(gfldo,icount)
 
-        endif   ! skip toral accumulated APCP variable
         ! end of probability forecast calculation
 
       endif   ! inum.gt.navg_min

--- a/sorc/build_aigefs_ensstat.sh
+++ b/sorc/build_aigefs_ensstat.sh
@@ -23,7 +23,7 @@ cd ${progname}.fd
 export FCMP=${FCMP:-ftn}
 export FCMP95=$FCMP
 
-if [ "$DEBUG" = 'Y' ] ; then
+if [ -v DEBUG && "$DEBUG" = 'Y' ] ; then
   #export FFLAGSM="-O0 -traceback -check all -ftrapuv -convert big_endian"
   export FFLAGSM="-O0 -traceback -g -check all -ftrapuv -convert big_endian"
 else


### PR DESCRIPTION
This PR is to fix a bug in code ensstat.f90 that causes f006 APCP filed missing in output files. The code previously had a line to identify two APCP variables. Since AIGEFS no longer outputs the total APCP, this line has been removed to prevent missing data.