### PR TITLE
Request exclusive node and 500GB memory

### DIFF
--- a/ecf/jaigefs_forecast.ecf
+++ b/ecf/jaigefs_forecast.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -l walltime=01:30:00
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l place=vscatter:shared,select=1:ncpus=128:mem=150GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128
 #PBS -l debug=true
 
 export model=aigefs


### PR DESCRIPTION
This PR changes the PBS resource request for `ecf/jaigefs_forecast.ecf` from shared and 150 GB memory to exclusive and (implicitly) 500 GB memory.