### PR TITLE
Add missing member subdirectory

### DIFF
--- a/parm/transfer_aigefs_mems15_30.list
+++ b/parm/transfer_aigefs_mems15_30.list
@@ -69,6 +69,7 @@ _COMROOT_/aigefs/_SHORTVER_/aigefs._PDYm1_/
 + /??/mem01[5-9]/model/atmos/grib2/aigefs.t??z.pres.f???.grib2.idx
 + /??/mem01[5-9]/model/atmos/grib2/aigefs.t??z.sfc.f???.grib2
 + /??/mem01[5-9]/model/atmos/grib2/aigefs.t??z.sfc.f???.grib2.idx
++ /??/mem02[0-9]/
 + /??/mem02[0-9]/model/
 + /??/mem02[0-9]/model/init/
 + /??/mem02[0-9]/model/init/aigefs.t??z.ic.nc


### PR DESCRIPTION
This PR adds a missing subdirectory to a transfer list file. This change ensures that aigefs data are transferred completely and in a timely manner between machines. No impacts to aigefs production jobs are expected from this change.